### PR TITLE
Bugfix #124: imports GPy before installing it

### DIFF
--- a/ezyrb/__init__.py
+++ b/ezyrb/__init__.py
@@ -4,16 +4,7 @@ __all__ = [
     'approximation', 'rbf', 'linear', 'gpr'
 ]
 
-__project__ = 'EZyRB'
-__title__ = "ezyrb"
-__author__ = "Nicola Demo, Marco Tezzele"
-__copyright__ = "Copyright 2016-2019, EZyRB contributors"
-__license__ = "MIT"
-__version__ = "1.0"
-__mail__ = 'demo.nicola@gmail.com, marcotez@gmail.com'
-__maintainer__ = __author__
-__status__ = "Stable"
-
+from .meta import *
 from .database import Database
 from .reduction import Reduction
 from .pod import POD

--- a/ezyrb/meta.py
+++ b/ezyrb/meta.py
@@ -1,3 +1,14 @@
+__all__ = [
+    '__project__',
+    '__title__',
+    '__author__',
+    '__copyright__',
+    '__license__',
+    '__version__',
+    '__mail__',
+    '__maintainer__',
+    '__status__']
+
 __project__ = 'EZyRB'
 __title__ = "ezyrb"
 __author__ = "Nicola Demo, Marco Tezzele"

--- a/ezyrb/meta.py
+++ b/ezyrb/meta.py
@@ -1,0 +1,9 @@
+__project__ = 'EZyRB'
+__title__ = "ezyrb"
+__author__ = "Nicola Demo, Marco Tezzele"
+__copyright__ = "Copyright 2016-2019, EZyRB contributors"
+__license__ = "MIT"
+__version__ = "1.0"
+__mail__ = 'demo.nicola@gmail.com, marcotez@gmail.com'
+__maintainer__ = __author__
+__status__ = "Stable"

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,19 @@
 from setuptools import setup, Command
 import os
 import sys
-import ezyrb
 from shutil import rmtree
 
+meta = {}
+with open("ezyrb/meta.py") as fp:
+    exec(fp.read(), meta)
+
 # Package meta-data.
-NAME = ezyrb.__title__
+NAME = meta['__title__']
 DESCRIPTION = 'Easy Reduced Basis'
 URL = 'https://github.com/mathLab/EZyRB'
-MAIL = ezyrb.__mail__
-AUTHOR = ezyrb.__author__
-VERSION = ezyrb.__version__
+MAIL = meta['__mail__']
+AUTHOR = meta['__author__']
+VERSION = meta['__version__']
 KEYWORDS='pod interpolation reduced-basis model-order-reduction'
 
 REQUIRED = [
@@ -75,10 +78,10 @@ setup(
     author=AUTHOR,
     author_email=MAIL,
 	classifiers=[
-	  	'Development Status :: 5 - Production/Stable',
-	  	'License :: OSI Approved :: MIT License',
-	  	'Programming Language :: Python :: 3.5',
-	  	'Programming Language :: Python :: 3.6',
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Mathematics'
 	],


### PR DESCRIPTION
This is solution number 3 on [this page](https://packaging.python.org/guides/single-sourcing-package-version/). Not perfect, but I'm not aware of any perfect solutions to this issue. Please let me know if you prefer another method.