### PR TITLE
Fix tutorial links

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -2,14 +2,11 @@
 
 In this folder you can find a collection of useful tutorials in order to understand the principles and the potential of **EZyRB**.
 
-#### [Tutorial 1 - Offline phase](tutorial-1-offline-phase.ipynb)
-Here we show the typical workflow for the construcion of the reduced basis space, called offline phase. The model reduction is done on a vtk pressure field.
-
-#### [Tutorial 2 - Online phase](tutorial-2-online-phase.ipynb)
-In this tutorial we show the workflow for the online evaluation of the output of interest. It is the natural continuation of the first tutorial on the vtk pressure field.
-
-#### [Tutorial 3 - Output interpolation](tutorial-3-interpolation.ipynb)
-Here we show how use the module mapper in order to interpolate the solutions (computed on meshes with different dimensions) on a new fixed dimension mesh.
+#### [Tutorial 1](tutorial-1.ipynb)
+Here we show the typical workflow on a vtk pressure field for:
+1. The construcion of the reduced basis space, called offline phase;
+2. The online evaluation of the output of interest;
+3. Using the module mapper in order to interpolate the solutions (computed on meshes with different dimensions) on a new fixed dimension mesh.
 
 
 #### More to come...

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -5,8 +5,7 @@ In this folder you can find a collection of useful tutorials in order to underst
 #### [Tutorial 1](tutorial-1.ipynb)
 Here we show the typical workflow on a vtk pressure field for:
 1. The construcion of the reduced basis space, called offline phase;
-2. The online evaluation of the output of interest;
-3. Using the module mapper in order to interpolate the solutions (computed on meshes with different dimensions) on a new fixed dimension mesh.
+2. The online evaluation of the output of interest.
 
 
 #### More to come...


### PR DESCRIPTION
c5963318ef23e78cd5f9e540f9b5f315d716595b removed these files:
- `tutorials/tutorial-1-offline-phase.ipynb `
- `tutorials/tutorial-2-online-phase.ipynb `
- `tutorials/tutorial-3-interpolation.ipynb `

While as far as I understand the three tutorials are now aggregated in `tutorial-1.ipynb`, the links haven't been fixed yet.