### PR TITLE
Add missing .conj()

### DIFF
--- a/ezyrb/pod.py
+++ b/ezyrb/pod.py
@@ -66,7 +66,7 @@ class POD(Reduction):
         :type: numpy.ndarray
         """
         self._modes, self._singular_values = self.__method(X)
-        return self.modes.T.dot(X)
+        return self.modes.T.conj().dot(X)
 
     def expand(self, X):
         """


### PR DESCRIPTION
This minor fix addresses the issue mentioned in #141.