### PR TITLE
FIx MacOS build problem 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
           python: 3.6
           env: TOXENV=py36
         - os: osx
+          osx_image: xcode12.2
           language: generic
           env: TOXENV=py36
 


### PR DESCRIPTION
Setting the attribute `osx_image` explicitly should fix the failing build mentioned in #143.