### PR TITLE
Add torch to required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 See the [**Examples**](#examples) section below and the [**Tutorials**](tutorials/README.md) to have an idea of the potential of this package.
 
 ## Dependencies and installation
-**EZyRB** requires `numpy`, `scipy`, `sklearn`, `matplotlib`, `vtk`, `nose` (for local
+**EZyRB** requires `numpy`, `scipy`, `sklearn`, `matplotlib`, `torch`, `vtk`, `nose` (for local
 test) and `sphinx` (to generate the documentation).The coe has been tested with
 Python3.5 version, but it should be compatible with Python3. It can be
 installed using `pip` or directly from the source code.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ VERSION = meta['__version__']
 KEYWORDS='pod interpolation reduced-basis model-order-reduction'
 
 REQUIRED = [
-    'future', 'numpy', 'scipy',	'matplotlib', 'GPy', 'sklearn'
+    'future', 'numpy', 'scipy',	'matplotlib', 'GPy', 'sklearn', 'torch'
 ]
 
 EXTRAS = {


### PR DESCRIPTION
The package `torch` is required in order to use EZyRB:
![image](https://user-images.githubusercontent.com/8464342/118731031-cfdd5380-b838-11eb-832c-1d82e2c1ea5d.png)
