### PR TITLE
Fix typo which breaks Linear 

### DIFF
--- a/ezyrb/linear.py
+++ b/ezyrb/linear.py
@@ -27,7 +27,7 @@ class Linear(Approximation):
         :param array_like points: the coordinates of the points.
         :param array_like values: the values in the points.
         """
-        self.intepolator = LinearNDInterpolator(points, values,
+        self.interpolator = LinearNDInterpolator(points, values,
             fill_value=self.fill_value)
 
     def predict(self, new_point):


### PR DESCRIPTION
Apparently this typo causes the failure of each call to `Linear.predict`, since the field `self.interpolator` doesn't exists after `Linear.fit`. 