### PR TITLE
Use interp1d as a special case for Linear, and tests for linear.py

### DIFF
--- a/ezyrb/linear.py
+++ b/ezyrb/linear.py
@@ -3,7 +3,7 @@ Module for Linear N-Dimensional Interpolation
 """
 
 import numpy as np
-from scipy.interpolate import LinearNDInterpolator
+from scipy.interpolate import LinearNDInterpolator, interp1d
 
 from .approximation import Approximation
 
@@ -27,8 +27,22 @@ class Linear(Approximation):
         :param array_like points: the coordinates of the points.
         :param array_like values: the values in the points.
         """
-        self.interpolator = LinearNDInterpolator(points, values,
-            fill_value=self.fill_value)
+        # the first dimension is the list of parameters, the second one is
+        # the dimensionality of each tuple of parameters (we look for
+        # parameters of dimensionality one)
+        as_np_array = np.array(points)
+        if not np.issubdtype(as_np_array.dtype, np.number):
+            raise ValueError('Invalid format or dimension for the argument `points`.')
+
+        if as_np_array.shape[-1] == 1:
+            as_np_array = np.squeeze(as_np_array, axis=-1)
+
+        if as_np_array.ndim == 1 or (as_np_array.ndim == 2 and
+            as_np_array.shape[1] == 1):
+            self.interpolator = interp1d(as_np_array, values, axis=0)
+        else:
+            self.interpolator = LinearNDInterpolator(points, values,
+                fill_value=self.fill_value)
 
     def predict(self, new_point):
         """

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1,0 +1,69 @@
+import numpy as np
+import warnings
+
+from unittest import TestCase
+from ezyrb import Linear, Database, POD, ReducedOrderModel
+
+class TestKNeighbors(TestCase):
+    def test_params(self):
+        reg = Linear(fill_value=0)
+        assert reg.fill_value == 0
+
+    def test_default_params(self):
+        reg = Linear()
+        assert np.isnan(reg.fill_value)
+
+    #def test_predict(self):
+    #    reg = Linear()
+    #    reg.fit([[1, 0, 0], [0, 1, 0], [0, 0, 1]], [[1, 0], [20, 5], [8, 6]])
+    #    result = reg.predict([[1,2], [8,9], [6,7]])
+    #    assert (result[0] == [1,0]).all()
+    #    assert (result[1] == [8,6]).all()
+    #    assert (result[2] == [20, 5]).all()
+
+    def test_predict1d(self):
+        reg = Linear()
+        reg.fit([[1], [6], [8]], [[1, 0], [20, 5], [8, 6]])
+        result = reg.predict([[1], [8], [6]])
+        assert (result[0] == [1,0]).all()
+        assert (result[1] == [8,6]).all()
+        assert (result[2] == [20, 5]).all()
+
+    def test_predict1d_2(self):
+        reg = Linear()
+        reg.fit([[1], [2]], [[1,1], [2,2]])
+        result = reg.predict([[1.5]])
+        assert (result[0] == [[1.5, 1.5]]).all()
+
+    def test_predict1d_3(self):
+        reg = Linear()
+        reg.fit([1,2], [[1,1], [2,2]])
+        result = reg.predict([[1.5]])
+        assert (result[0] == [[1.5,1.5]]).all()
+
+    def test_with_db_predict(self):
+        reg = Linear()
+        pod = POD()
+        db = Database(np.array([1, 2, 3])[:,None], np.array([1, 5, 3])[:,None])
+        rom = ReducedOrderModel(db, pod, reg)
+
+        rom.fit()
+        assert rom.predict([1]) == 1
+        assert rom.predict([2]) == 5
+        assert rom.predict([3]) == 3
+
+    def test_wrong1(self):
+        # wrong number of params
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
+            with self.assertRaises(Exception):
+                reg = Linear()
+                reg.fit([[1, 2], [6,], [8, 9]], [[1, 0], [20, 5], [8, 6]])
+
+    def test_wrong2(self):
+        # wrong number of values
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
+            with self.assertRaises(Exception):
+                reg = Linear()
+                reg.fit([[1, 2], [6,], [8, 9]], [[20, 5], [8, 6]])


### PR DESCRIPTION
In this commit I add a special case to `Linear`, in order to use `scipy.interpolate.interp1d` when parameters are 1D (at the moment `Linear` fails in this case).

Moreover I added some tests to `Linear`. Can someone please write or suggest a meaningful test case for `Linear` in the case `ND x MD`? (the commented method `test_predict` in `test_linear.py`). I keep getting errors like
```
scipy.spatial.qhull.QhullError: QH6214 qhull input error: not enough points(3) to construct initial simplex (need 5)
```
and 
```
scipy.spatial.qhull.QhullError: QH6154 Qhull precision error: Initial simplex is flat (facet 1 is coplanar with the interior point)
```
