### PR TITLE
Transform

### DIFF
--- a/docs/source/ae.rst
+++ b/docs/source/ae.rst
@@ -13,6 +13,8 @@ AE
     AE.fit
     AE.reduce
     AE.expand
+    AE.transform
+    AE.inverse_transform
     AE._build_model
 
 .. autoclass:: AE

--- a/docs/source/code.rst
+++ b/docs/source/code.rst
@@ -15,4 +15,5 @@ Code Documentation
    reduction
    pod
    ae
+   podae
    reducedordermodel

--- a/docs/source/pod.rst
+++ b/docs/source/pod.rst
@@ -14,6 +14,8 @@ POD
     POD.singular_values
     POD.reduce
     POD.expand
+    POD.transform
+    POD.inverse_transform
     POD._truncation
     POD._svd
     POD._rsvd

--- a/docs/source/podae.rst
+++ b/docs/source/podae.rst
@@ -1,0 +1,24 @@
+PODAE
+=====================
+
+.. currentmodule:: ezyrb.podae
+
+.. automodule:: ezyrb.podae
+
+.. autosummary::
+    :toctree: _summaries
+    :nosignatures:
+
+    PODAE
+    PODAE.fit
+    PODAE.reduce
+    PODAE.expand
+    PODAE.transform
+    PODAE.inverse_transform
+
+.. autoclass:: PODAE
+    :members:
+    :private-members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:

--- a/docs/source/podae.rst
+++ b/docs/source/podae.rst
@@ -1,9 +1,9 @@
 PODAE
 =====================
 
-.. currentmodule:: ezyrb.podae
+.. currentmodule:: ezyrb.pod_ae
 
-.. automodule:: ezyrb.podae
+.. automodule:: ezyrb.pod_ae
 
 .. autosummary::
     :toctree: _summaries

--- a/docs/source/reduction.rst
+++ b/docs/source/reduction.rst
@@ -12,6 +12,8 @@ Reduction
     Reduction
     Reduction.reduce
     Reduction.expand
+    Reduction.transform
+    Reduction.inverse_transform
 
 .. autoclass:: Reduction
     :members:

--- a/ezyrb/ae.py
+++ b/ezyrb/ae.py
@@ -207,24 +207,24 @@ class AE(Reduction, ANN):
 
     def reduce(self, X):
         """
-        .. note::
-
-            Same as `transform`. Kept for backward compatibility.
-        
         Reduces the given snapshots.
 
         :param numpy.ndarray X: the input snapshots matrix (stored by column).
+
+        .. note::
+
+            Same as `transform`. Kept for backward compatibility.
         """
         return self.transform(X)
 
     def expand(self, g):
         """
-        .. note::
-
-            Same as `inverse_transform`. Kept for backward compatibility.
-        
         Projects a reduced to full order solution.
 
         :param: numpy.ndarray g the latent variables.
+
+        .. note::
+
+            Same as `inverse_transform`. Kept for backward compatibility.
         """
         return self.inverse_transform(g)

--- a/ezyrb/ae.py
+++ b/ezyrb/ae.py
@@ -185,7 +185,7 @@ class AE(Reduction, ANN):
 
             n_epoch += 1
 
-    def reduce(self, X):
+    def transform(self, X):
         """
         Reduces the given snapshots.
 
@@ -195,7 +195,7 @@ class AE(Reduction, ANN):
         g = self.encoder(X)
         return g.cpu().detach().numpy().T
 
-    def expand(self, g):
+    def inverse_transform(self, g):
         """
         Projects a reduced to full order solution.
 
@@ -204,3 +204,27 @@ class AE(Reduction, ANN):
         g = self._convert_numpy_to_torch(g).T
         u = self.decoder(g)
         return u.cpu().detach().numpy().T
+
+    def reduce(self, X):
+        """
+        .. note::
+
+            Same as `transform`. Kept for backward compatibility.
+        
+        Reduces the given snapshots.
+
+        :param numpy.ndarray X: the input snapshots matrix (stored by column).
+        """
+        return self.transform(X)
+
+    def expand(self, g):
+        """
+        .. note::
+
+            Same as `inverse_transform`. Kept for backward compatibility.
+        
+        Projects a reduced to full order solution.
+
+        :param: numpy.ndarray g the latent variables.
+        """
+        return self.inverse_transform(g)

--- a/ezyrb/pod.py
+++ b/ezyrb/pod.py
@@ -129,25 +129,25 @@ class POD(Reduction):
 
     def reduce(self, X):
         """
-        .. note::
-
-            Same as `transform`. Kept for backward compatibility.
-        
         Reduces the given snapshots.
 
         :param numpy.ndarray X: the input snapshots matrix (stored by column).
+
+        .. note::
+
+            Same as `transform`. Kept for backward compatibility.
         """
         return self.transform(X)
 
     def expand(self, X):
         """
-        .. note::
-
-            Same as `inverse_transform`. Kept for backward compatibility.
-        
         Projects a reduced to full order solution.
 
         :type: numpy.ndarray
+
+        .. note::
+
+            Same as `inverse_transform`. Kept for backward compatibility.
         """
         return self.inverse_transform(X)
 

--- a/ezyrb/pod.py
+++ b/ezyrb/pod.py
@@ -111,7 +111,7 @@ class POD(Reduction):
         self._modes, self._singular_values = self.__method(X)
         return self
 
-    def reduce(self, X):
+    def transform(self, X):
         """
         Reduces the given snapshots.
 
@@ -119,13 +119,37 @@ class POD(Reduction):
         """
         return self.modes.T.conj().dot(X)
 
-    def expand(self, X):
+    def inverse_transform(self, X):
         """
         Projects a reduced to full order solution.
 
         :type: numpy.ndarray
         """
         return self.modes.dot(X)
+
+    def reduce(self, X):
+        """
+        .. note::
+
+            Same as `transform`. Kept for backward compatibility.
+        
+        Reduces the given snapshots.
+
+        :param numpy.ndarray X: the input snapshots matrix (stored by column).
+        """
+        return self.transform(X)
+
+    def expand(self, X):
+        """
+        .. note::
+
+            Same as `inverse_transform`. Kept for backward compatibility.
+        
+        Projects a reduced to full order solution.
+
+        :type: numpy.ndarray
+        """
+        return self.inverse_transform(X)
 
     def _truncation(self, X, s):
         """

--- a/ezyrb/pod_ae.py
+++ b/ezyrb/pod_ae.py
@@ -48,24 +48,24 @@ class PODAE(POD, AE):
 
     def reduce(self, X):
         """
-        .. note::
-
-            Same as `transform`. Kept for backward compatibility.
-        
         Reduces the given snapshots.
 
         :param numpy.ndarray X: the input snapshots matrix (stored by column).
+
+        .. note::
+
+            Same as `transform`. Kept for backward compatibility.
         """
         return self.transform(X)
 
     def expand(self, g):
         """
-        .. note::
-
-            Same as `inverse_transform`. Kept for backward compatibility.
-        
         Projects a reduced to full order solution.
 
         :param: numpy.ndarray g the latent variables.
+        
+        .. note::
+
+            Same as `inverse_transform`. Kept for backward compatibility.
         """
         return self.inverse_transform(g)

--- a/ezyrb/pod_ae.py
+++ b/ezyrb/pod_ae.py
@@ -21,10 +21,10 @@ class PODAE(POD, AE):
         """
         """
         self.pod.fit(X)
-        coefficients = self.pod.reduce(X)
+        coefficients = self.pod.transform(X)
         self.ae.fit(coefficients)
 
-    def reduce(self, X):
+    def transform(self, X):
         """
         Reduces the given snapshots.
 
@@ -35,7 +35,7 @@ class PODAE(POD, AE):
         g = self.ae.encoder(coeff)
         return g.cpu().detach().numpy().T
 
-    def expand(self, g):
+    def inverse_transform(self, g):
         """
         Projects a reduced to full order solution.
 
@@ -45,3 +45,27 @@ class PODAE(POD, AE):
         u = self.ae.decoder(g)
         u = u.cpu().detach().numpy().T
         return self.pod.expand(u)
+
+    def reduce(self, X):
+        """
+        .. note::
+
+            Same as `transform`. Kept for backward compatibility.
+        
+        Reduces the given snapshots.
+
+        :param numpy.ndarray X: the input snapshots matrix (stored by column).
+        """
+        return self.transform(X)
+
+    def expand(self, g):
+        """
+        .. note::
+
+            Same as `inverse_transform`. Kept for backward compatibility.
+        
+        Projects a reduced to full order solution.
+
+        :param: numpy.ndarray g the latent variables.
+        """
+        return self.inverse_transform(g)

--- a/ezyrb/reducedordermodel.py
+++ b/ezyrb/reducedordermodel.py
@@ -56,7 +56,7 @@ class ReducedOrderModel():
         self.reduction.fit(self.database.snapshots.T)
         self.approximation.fit(
             self.database.parameters,
-            self.reduction.reduce(self.database.snapshots.T).T,
+            self.reduction.transform(self.database.snapshots.T).T,
             *args,
             **kwargs)
 
@@ -66,7 +66,7 @@ class ReducedOrderModel():
         """
         Calculate predicted solution for given mu
         """
-        predicted_sol = self.reduction.expand(
+        predicted_sol = self.reduction.inverse_transform(
             np.atleast_2d(self.approximation.predict(mu)).T)
         if 1 in predicted_sol.shape:
             predicted_sol = predicted_sol.ravel()

--- a/ezyrb/reduction.py
+++ b/ezyrb/reduction.py
@@ -15,9 +15,9 @@ class Reduction(ABC):
         """Abstract `fit`"""
 
     @abstractmethod
-    def reduce(self):
-        """Abstract `reduce`"""
+    def transform(self):
+        """Abstract `transform`"""
 
     @abstractmethod
-    def expand(self):
-        """Abstract `expand`"""
+    def inverse_transform(self):
+        """Abstract `inverse_transform`"""

--- a/tests/test_ae.py
+++ b/tests/test_ae.py
@@ -15,7 +15,7 @@ class TestAE(TestCase):
         f = torch.nn.Softplus
         ae = AE([400, 20, 2], [2, 20, 400], f(), f(), 1e-5)
         ae.fit(snapshots)
-        snapshots_ = ae.expand(ae.reduce(snapshots))
+        snapshots_ = ae.inverse_transform(ae.transform(snapshots))
         rerr = np.linalg.norm(snapshots_ - snapshots)/np.linalg.norm(snapshots)
         assert rerr < 5e-3
 
@@ -24,7 +24,7 @@ class TestAE(TestCase):
         low_dim = 5
         ae = AE([400, low_dim], [low_dim, 400], f(), f(), 20)
         ae.fit(snapshots)
-        reduced_snapshots = ae.reduce(snapshots)
+        reduced_snapshots = ae.transform(snapshots)
         assert reduced_snapshots.shape[0] == low_dim
-        expanded_snapshots = ae.expand(reduced_snapshots)
+        expanded_snapshots = ae.inverse_transform(reduced_snapshots)
         assert expanded_snapshots.shape[0] == snapshots.shape[0]

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -14,20 +14,40 @@ class TestPOD(TestCase):
 
     def test_numpysvd(self):
         pod = POD('svd').fit(snapshots)
-        snapshots_ = pod.expand(pod.reduce(snapshots))
+        snapshots_ = pod.inverse_transform(pod.transform(snapshots))
         np.testing.assert_array_almost_equal(snapshots, snapshots_, decimal=4)
 
     def test_correlation_matrix(self):
         pod = POD('correlation_matrix').fit(snapshots)
-        snapshots_ = pod.expand(pod.reduce(snapshots))
+        snapshots_ = pod.inverse_transform(pod.transform(snapshots))
         np.testing.assert_array_almost_equal(snapshots, snapshots_, decimal=3)
 
     def test_correlation_matirix_savemem(self):
         pod = POD('correlation_matrix', save_memory=True).fit(snapshots)
-        snapshots_ = pod.expand(pod.reduce(snapshots))
+        snapshots_ = pod.inverse_transform(pod.transform(snapshots))
         np.testing.assert_array_almost_equal(snapshots, snapshots_, decimal=4)
 
     def test_randomized_svd(self):
+        pod = POD('randomized_svd', save_memory=False).fit(snapshots)
+        snapshots_ = pod.inverse_transform(pod.transform(snapshots))
+        np.testing.assert_array_almost_equal(snapshots, snapshots_, decimal=4)
+
+    def test_numpysvd_old(self):
+        pod = POD('svd').fit(snapshots)
+        snapshots_ = pod.expand(pod.reduce(snapshots))
+        np.testing.assert_array_almost_equal(snapshots, snapshots_, decimal=4)
+
+    def test_correlation_matrix_old(self):
+        pod = POD('correlation_matrix').fit(snapshots)
+        snapshots_ = pod.expand(pod.reduce(snapshots))
+        np.testing.assert_array_almost_equal(snapshots, snapshots_, decimal=3)
+
+    def test_correlation_matirix_savemem_old(self):
+        pod = POD('correlation_matrix', save_memory=True).fit(snapshots)
+        snapshots_ = pod.expand(pod.reduce(snapshots))
+        np.testing.assert_array_almost_equal(snapshots, snapshots_, decimal=4)
+
+    def test_randomized_svd_old(self):
         pod = POD('randomized_svd', save_memory=False).fit(snapshots)
         snapshots_ = pod.expand(pod.reduce(snapshots))
         np.testing.assert_array_almost_equal(snapshots, snapshots_, decimal=4)

--- a/tests/test_podae.py
+++ b/tests/test_podae.py
@@ -19,7 +19,7 @@ class TestAE(TestCase):
         pod = POD(rank=4)
         podae = PODAE(pod, ae)
         podae.fit(snapshots)
-        snapshots_ = podae.expand(podae.reduce(snapshots))
+        snapshots_ = podae.inverse_transform(podae.transform(snapshots))
         rerr = np.linalg.norm(snapshots_ - snapshots)/np.linalg.norm(snapshots)
         assert rerr < 5e-3
 


### PR DESCRIPTION
This PR uniform the package to the scikit API. In particular there is a refactor of `reduce` and `expand` to `transform` and `inverse_transform`, respectively. The old methods are kept only for backward compatibility, and now they link to the new methods.

This PR adds also the doc files for the pod_ae module, addressing #195 