### PR TITLE
Scaling in rom.predict

### DIFF
--- a/ezyrb/reducedordermodel.py
+++ b/ezyrb/reducedordermodel.py
@@ -66,8 +66,17 @@ class ReducedOrderModel():
         """
         Calculate predicted solution for given mu
         """
+        mu = np.atleast_2d(mu)
+        if hasattr(self, 'database') and self.database.scaler_parameters:
+            mu = self.database.scaler_parameters.transform(mu)
+
         predicted_sol = self.reduction.inverse_transform(
             np.atleast_2d(self.approximation.predict(mu)).T)
+
+        if hasattr(self, 'database') and self.database.scaler_snapshots:
+            predicted_sol = self.database.scaler_snapshots.inverse_transform(
+                    predicted_sol.T).T
+
         if 1 in predicted_sol.shape:
             predicted_sol = predicted_sol.ravel()
         else:
@@ -247,7 +256,7 @@ class ReducedOrderModel():
         simplex.
         Source from: `wikipedia.org/wiki/Simplex
         <https://en.wikipedia.org/wiki/Simplex>`_.
-        
+
         :param numpy.ndarray simplex_vertices: Nx3 array containing the
             parameter values representing the vertices of a simplex. N is the
             dimensionality of the parameters.

--- a/tests/test_reducedordermodel.py
+++ b/tests/test_reducedordermodel.py
@@ -89,6 +89,31 @@ class TestReducedOrderModel(TestCase):
         pred_sol = rom.predict(db.parameters)
         assert pred_sol.shape == db.snapshots.shape
 
+    def test_predict_scaler_01(self):
+        from sklearn.preprocessing import StandardScaler
+        scaler = StandardScaler()
+        pod = POD()
+        rbf = RBF()
+        db = Database(param, snapshots.T, scaler_snapshots=scaler)
+        rom = ROM(db, pod, rbf).fit()
+        pred_sol = rom.predict(db.parameters[0])
+        np.testing.assert_allclose(pred_sol, db._snapshots[0], rtol=1e-4, atol=1e-5)
+        pred_sol = rom.predict(db.parameters[0:2])
+        np.testing.assert_allclose(pred_sol, db._snapshots[0:2], rtol=1e-4, atol=1e-5)
+
+    def test_predict_scaler_02(self):
+        from sklearn.preprocessing import StandardScaler
+        scaler_p = StandardScaler()
+        scaler_s = StandardScaler()
+        pod = POD()
+        rbf = RBF()
+        db = Database(param, snapshots.T, scaler_parameters=scaler_p, scaler_snapshots=scaler_s)
+        rom = ROM(db, pod, rbf).fit()
+        pred_sol = rom.predict(db._parameters[0])
+        np.testing.assert_allclose(pred_sol, db._snapshots[0], rtol=1e-4, atol=1e-5)
+        pred_sol = rom.predict(db._parameters[0:2])
+        np.testing.assert_allclose(pred_sol, db._snapshots[0:2], rtol=1e-4, atol=1e-5)
+
     def test_test_error(self):
         pod = POD(method='svd', rank=-1)
         rbf = RBF()


### PR DESCRIPTION
Now `ReducedOrderModel.predict` method scale the parameter and the approximated solution if the database has set `scaler_snapshots` and `scaler_parameters`.

Fix #193 