### PR TITLE
Add argument for scaling reduced variables

### DIFF
--- a/tests/test_reducedordermodel.py
+++ b/tests/test_reducedordermodel.py
@@ -114,6 +114,18 @@ class TestReducedOrderModel(TestCase):
         pred_sol = rom.predict(db._parameters[0:2])
         np.testing.assert_allclose(pred_sol, db._snapshots[0:2], rtol=1e-4, atol=1e-5)
 
+    def test_predict_scaling_coeffs(self):
+        from sklearn.preprocessing import StandardScaler
+        scaler = StandardScaler()
+        pod = POD()
+        rbf = RBF()
+        db = Database(param, snapshots.T)
+        rom = ROM(db, pod, rbf, scaler).fit()
+        pred_sol = rom.predict(db._parameters[0])
+        np.testing.assert_allclose(pred_sol, db._snapshots[0], rtol=1e-4, atol=1e-5)
+        pred_sol = rom.predict(db._parameters[0:2])
+        np.testing.assert_allclose(pred_sol, db._snapshots[0:2], rtol=1e-4, atol=1e-5)
+
     def test_test_error(self):
         pod = POD(method='svd', rank=-1)
         rbf = RBF()


### PR DESCRIPTION
Now it's possible to normalize the "reduced variable" (in the POD model the so-called modal coefficients) before constructing the approximation. 