### PR TITLE
Regular grid interpolation

### DIFF
--- a/docs/source/code.rst
+++ b/docs/source/code.rst
@@ -17,3 +17,4 @@ Code Documentation
    ae
    podae
    reducedordermodel
+   regular_grid

--- a/docs/source/regular_grid.rst
+++ b/docs/source/regular_grid.rst
@@ -10,7 +10,6 @@ RegularGrid
     :nosignatures:
 
     RegularGrid
-    RegularGrid.def
     RegularGrid.get_grid_axes
     RegularGrid.fit
     RegularGrid.predict

--- a/docs/source/regular_grid.rst
+++ b/docs/source/regular_grid.rst
@@ -1,0 +1,23 @@
+RegularGrid
+=====================
+
+.. currentmodule:: ezyrb.regular_grid
+
+.. automodule:: ezyrb.regular_grid
+
+.. autosummary::
+    :toctree: _summaries
+    :nosignatures:
+
+    RegularGrid
+    RegularGrid.get_grid_axes
+    RegularGrid.fit
+    RegularGrid.predict
+    RegularGrid.calculate_flat_index
+
+.. autoclass:: RegularGrid
+    :members:
+    :private-members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:

--- a/docs/source/regular_grid.rst
+++ b/docs/source/regular_grid.rst
@@ -10,10 +10,10 @@ RegularGrid
     :nosignatures:
 
     RegularGrid
+    RegularGrid.def
     RegularGrid.get_grid_axes
     RegularGrid.fit
     RegularGrid.predict
-    RegularGrid.calculate_flat_index
 
 .. autoclass:: RegularGrid
     :members:

--- a/ezyrb/__init__.py
+++ b/ezyrb/__init__.py
@@ -3,7 +3,7 @@
 __all__ = [
     'Database', 'Reduction', 'POD', 'Approximation', 'RBF', 'Linear', 'GPR',
     'ANN', 'KNeighborsRegressor', 'RadiusNeighborsRegressor', 'AE',
-    'ReducedOrderModel', 'PODAE'
+    'ReducedOrderModel', 'PODAE', 'RegularGrid'
 ]
 
 from .meta import *
@@ -15,6 +15,7 @@ from .pod_ae import PODAE
 from .approximation import Approximation
 from .rbf import RBF
 from .linear import Linear
+from .regular_grid import RegularGrid
 from .gpr import GPR
 from .reducedordermodel import ReducedOrderModel
 from .ann import ANN

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -130,11 +130,11 @@ class RegularGrid(Approximation):
         if len(new_point.shape) == 1:
             new_point.shape = (-1, 1)
 
-        dim = self.dim
         if self.n_modes > 1:
-            xi_extended = np.zeros((len(self.mode_nr), len(new_point), dim+1))
+            shape = (len(self.mode_nr), len(new_point), self.dim+1)
+            xi_extended = np.zeros(shape)
             xi_extended[:, :, 0] = self.mode_nr[:, None]
-            for i in range(dim):
+            for i in range(self.dim):
                 xi_extended[:, :, i+1] = np.array(new_point)[:, i]
         else:
             xi_extended = new_point

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -25,30 +25,21 @@ class RegularGrid(Approximation):
     def fit(self, points, values, **kvargs):
         """
         Construct the interpolator given `points` and `values`.
+        see scipy.interpolate.RegularGridInterpolator
 
-        Parameters
-        ----------
-        points : tuple of ndarray of float, with shapes (m1, ), ..., (mn, )
+        :param array_like points: with shapes (m1, ), ..., (mn, )
             The points defining the regular grid in n dimensions. The points in
             each dimension (i.e. every elements of the points tuple) must be
             strictly ascending or descending.
 
-        values : array_like, shape (m1, ..., mn, ...)
-            The data on the regular grid in n dimensions. Complex data can be
-            acceptable.
-        **kvargs : TYPE
-            see scipy.interpolate.RegularGridInterpolator
-
-        Returns
-        -------
-        None.
-
+        :param array_like values: shape (m1, ..., mn, ...)
+            The data on the regular grid in n dimensions.
         """
         # we have two options
         # 1.: we could make an interpolator for every mode and its coefficients
         # or 2.: we "interpolate" the mode number
         # option 1 is cleaner, but option 2 performs better
-        # X = U S VT, X being shaped m, n
+        # X = U S VT, X being shaped (m, n)
 
         self.dim = len(points)
         vals = np.asarray(values)

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -95,8 +95,8 @@ class RegularGrid(Approximation):
         if not np.issubdtype(points.dtype, np.number):
             raise ValueError('Invalid format or dimension for the argument'
                              '`points`.')
-        if len(points.shape) == 1:
-            points.shape = (-1, 1)
+        if points.ndim == 1:
+            points = points[:, None]
         vals = np.asarray(values)
         grid_axes, values_grd = self.get_grid_axes(points, vals)
         shape = [len(ax) for ax in grid_axes]
@@ -112,6 +112,6 @@ class RegularGrid(Approximation):
         :rtype: numpy.ndarray
         """
         new_point = np.asarray(new_point)
-        if len(new_point.shape) == 1:
-            new_point.shape = (-1, 1)
+        if new_point.ndim == 1:
+            new_point = new_point[:, None]
         return self.interpolator(new_point)

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -73,7 +73,6 @@ class RegularGrid(Approximation):
             nN.append(len(xn))
             iN.append(unique_inverse_n)
         if np.prod(nN) != len(vals_scrmbld):
-            print(nN, len(vals_scrmbld))
             msg = "Values don't match grid. Make sure to pass a list of "\
                   "points that are on a regular grid! Be aware of floating "\
                   "point precision."
@@ -96,7 +95,8 @@ class RegularGrid(Approximation):
         if not np.issubdtype(points.dtype, np.number):
             raise ValueError('Invalid format or dimension for the argument'
                              '`points`.')
-        points = np.atleast_2d(points)
+        if len(points.shape) == 1:
+            points.shape = (-1, 1)
         vals = np.asarray(values)
         grid_axes, values_grd = self.get_grid_axes(points, vals)
         shape = [len(ax) for ax in grid_axes]

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -119,6 +119,13 @@ class RegularGrid(Approximation):
                                 **kwargs)
 
     def predict(self, new_point):
+        """
+        Evaluate interpolator at given `new_point`, can be multiple points.
+
+        :param array_like new_point: the coordinates of the given point(s).
+        :return: the interpolated values.
+        :rtype: numpy.ndarray
+        """
         new_point = np.array(new_point)
         if len(new_point.shape) == 1:
             new_point.shape = (-1, 1)

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -1,0 +1,59 @@
+"""
+Module for higher order interpolation on regular grids
+"""
+
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+
+from .approximation import Approximation
+
+
+class RegularGrid(Approximation):
+    """
+    Multidimensional interpolator on regular grids.
+
+    :param float fill_value: value used to fill in for requested points outside
+        of the convex hull of the input points. If not provided, then the
+        default is numpy.nan.
+    """
+
+    def __init__(self, fill_value=np.nan):
+        self.fill_value = fill_value
+        self.interpolator = None
+
+    def fit(self, grid, values):
+        """
+        Construct the interpolator given `grid` and `values`.
+
+        :param array_like points: the coordinates of the points.
+        :param array_like values: the values in the points.
+        """
+        # the first dimension is the list of parameters, the second one is
+        # the dimensionality of each tuple of parameters (we look for
+        # parameters of dimensionality one)
+
+        # as_np_array = np.array(points)
+        # if not np.issubdtype(as_np_array.dtype, np.number):
+        #     raise ValueError('Invalid format or dimension for the argument'
+        #                      '`points`.')
+
+        # if as_np_array.shape[-1] == 1:
+        #     as_np_array = np.squeeze(as_np_array, axis=-1)
+
+        # if as_np_array.ndim == 1 or (as_np_array.ndim == 2
+        #                              and as_np_array.shape[1] == 1):
+        #     self.interpolator = interp1d(as_np_array, values, axis=0)
+        # else:
+        #     self.interpolator = LinearNDInterp(points,
+        #                                        values,
+        #                                        fill_value=self.fill_value)
+
+    def predict(self, new_point):
+        """
+        Evaluate interpolator at given `new_points`.
+
+        :param array_like new_points: the coordinates of the given points.
+        :return: the interpolated values.
+        :rtype: numpy.ndarray
+        """
+        return self.interpolator(new_point)

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -9,6 +9,7 @@ from .approximation import Approximation
 class RegularGrid(Approximation):
     """
     Multidimensional interpolator on regular grids.
+    See scipy's RegularGridInterpolator
 
     :param float fill_value: value used to fill in for requested points outside
         of the convex hull of the input points. If not provided, then the
@@ -18,14 +19,30 @@ class RegularGrid(Approximation):
     def __init__(self, fill_value=np.nan):
         self.fill_value = fill_value
         self.interpolator = None
-        return
+        self.dim = None
+        self.mode_nr = None
 
-    def fit(self, grid, values, **kvargs):
+    def fit(self, points, values, **kvargs):
         """
-        Construct the interpolator given `grid` and `values`.
+        Construct the interpolator given `points` and `values`.
 
-        :param array_like points: the coordinates of the points.
-        :param array_like values: the values in the points.
+        Parameters
+        ----------
+        points : tuple of ndarray of float, with shapes (m1, ), ..., (mn, )
+            The points defining the regular grid in n dimensions. The points in
+            each dimension (i.e. every elements of the points tuple) must be
+            strictly ascending or descending.
+
+        values : array_like, shape (m1, ..., mn, ...)
+            The data on the regular grid in n dimensions. Complex data can be
+            acceptable.
+        **kvargs : TYPE
+            see scipy.interpolate.RegularGridInterpolator
+
+        Returns
+        -------
+        None.
+
         """
         # we have two options
         # 1.: we could make an interpolator for every mode and its coefficients
@@ -33,14 +50,14 @@ class RegularGrid(Approximation):
         # option 1 is cleaner, but option 2 performs better
         # X = U S VT, X being shaped m, n
 
-        self.dim = len(grid)
+        self.dim = len(points)
         vals = np.asarray(values)
-        r, n = vals.T.shape  # vals = (S*VT).T
+        r = vals.T.shape[0]  # vals = (S*VT).T
         self.mode_nr = np.arange(r)
-        extended_grid = [self.mode_nr, *grid]
+        extended_grid = [self.mode_nr, *points]
         shape = [r, ]
         for i in range(self.dim):
-            shape.append(len(grid[i]))
+            shape.append(len(points[i]))
         assert np.prod(shape) == vals.size, "Values don't match grid. "\
             "Make sure to pass a grid, not a list of points!\n"\
             "HINT: did you use rom.fit()? This method does not work with a "\
@@ -49,19 +66,11 @@ class RegularGrid(Approximation):
                                                     vals.T.reshape(shape),
                                                     fill_value=self.fill_value,
                                                     **kvargs)
-        return
 
-    def predict(self, new_points):
-        """
-        Evaluate interpolator at given `new_points`.
-
-        :param array_like new_points: the coordinates of the given points.
-        :return: the interpolated values.
-        :rtype: numpy.ndarray
-        """
+    def predict(self, new_point):
         dim = self.dim
-        xi_extended = np.zeros((len(self.mode_nr), len(new_points), dim+1))
+        xi_extended = np.zeros((len(self.mode_nr), len(new_point), dim+1))
         xi_extended[:, :, 0] = self.mode_nr[:, None]
         for i in range(dim):
-            xi_extended[:, :, i+1] = np.array(new_points)[:, i]
+            xi_extended[:, :, i+1] = np.array(new_point)[:, i]
         return self.interpolator(xi_extended).T

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -22,6 +22,16 @@ class RegularGrid(Approximation):
         self.dim = None
         self.mode_nr = None
 
+    def get_grid_axes(self, pts_scrmbld, vals_scrmbld):
+        # rounding errors!
+        # works in 2D
+        x1, unique_inverse1 = np.unique(pts_scrmbld[:, 0], return_inverse=True)
+        x2, unique_inverse2 = np.unique(pts_scrmbld[:, 1], return_inverse=True)
+        new_row_index = unique_inverse1*len(x2)+unique_inverse2
+        reverse_scrambling = np.argsort(new_row_index)
+        vals_on_regular_grid = vals_scrmbld[reverse_scrambling, :]
+        return (x1, x2), vals_on_regular_grid
+
     def fit(self, points, values, **kvargs):
         """
         Construct the interpolator given `points` and `values`.

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -11,13 +11,9 @@ class RegularGrid(Approximation):
     Multidimensional interpolator on regular grids.
     See scipy's RegularGridInterpolator
 
-    :param float fill_value: value used to fill in for requested points outside
-        of the convex hull of the input points. If not provided, then the
-        default is numpy.nan.
     """
 
-    def __init__(self, fill_value=np.nan):
-        self.fill_value = fill_value
+    def __init__(self):
         self.interpolator = None
         self.dim = None
         self.n_modes = 0
@@ -92,7 +88,6 @@ class RegularGrid(Approximation):
         self.interpolator = RegularGridInterpolator(extended_grid,
                                                     values_grd.T.reshape(
                                                         shape),
-                                                    fill_value=self.fill_value,
                                                     **kvargs)
 
     def predict(self, new_point):

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -80,7 +80,7 @@ class RegularGrid(Approximation):
                   "points that are on a regular grid! Be aware of floating "\
                   "point precision."
             raise ValueError(msg)
-        new_row_index = calculate_flat_index(iN, nN)
+        new_row_index = np.ravel_multi_index(iN, nN)
         reverse_scrambling = np.argsort(new_row_index)
         vals_on_regular_grid = vals_scrmbld[reverse_scrambling, :]
         return grid_axes, vals_on_regular_grid
@@ -139,28 +139,3 @@ class RegularGrid(Approximation):
         else:
             xi_extended = new_point
         return self.interpolator(xi_extended).T
-
-
-def calculate_flat_index(iN, nN):
-    """
-    Calculates the flat index for a multidimensional array given the indices
-    and dimensions.
-
-    :param list iN: indices representing the position of the element(s)
-                    in each dimension.
-    :param list nN: size of the array in each dimension.
-
-    :rtype: numpy.ndarray
-    """
-    # index = i1 + n1 * (i2 + n2 * (... (iN-1 + nN-1 * iN) ...))
-    if len(iN) != len(nN):
-        raise ValueError("The lengths of iN and nN should be the same.")
-
-    if any((i < 0).any() or (i >= n).any() for i, n in zip(iN, nN)):
-        raise ValueError("The indices are out of bounds.")
-
-    index = 0
-    for i, n in zip(iN, nN):
-        index = i + n * index
-
-    return index

--- a/ezyrb/regular_grid.py
+++ b/ezyrb/regular_grid.py
@@ -1,10 +1,8 @@
 """
 Module for higher order interpolation on regular grids
 """
-
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator
-
 from .approximation import Approximation
 
 
@@ -20,6 +18,7 @@ class RegularGrid(Approximation):
     def __init__(self, fill_value=np.nan):
         self.fill_value = fill_value
         self.interpolator = None
+        return
 
     def fit(self, grid, values, **kvargs):
         """
@@ -28,10 +27,6 @@ class RegularGrid(Approximation):
         :param array_like points: the coordinates of the points.
         :param array_like values: the values in the points.
         """
-        # the first dimension is the list of parameters, the second one is
-        # the dimensionality of each tuple of parameters (we look for
-        # parameters of dimensionality one)
-
         # we have two options
         # 1.: we could make an interpolator for every mode and its coefficients
         # or 2.: we "interpolate" the mode number
@@ -54,6 +49,7 @@ class RegularGrid(Approximation):
                                                     vals.T.reshape(shape),
                                                     fill_value=self.fill_value,
                                                     **kvargs)
+        return
 
     def predict(self, new_points):
         """

--- a/tests/test_regular_grid.py
+++ b/tests/test_regular_grid.py
@@ -1,0 +1,75 @@
+import numpy as np
+import warnings
+
+from unittest import TestCase
+from ezyrb import Linear, Database, POD, ReducedOrderModel, RegularGrid
+
+
+class TestRegularGrid(TestCase):
+    def test_params(self):
+        reg = RegularGrid(fill_value=0)
+        assert reg.fill_value == 0
+
+    def test_default_params(self):
+        reg = RegularGrid()
+        assert np.isnan(reg.fill_value)
+
+    # def test_predict(self):
+    #    reg = Linear()
+    #    reg.fit([[1, 0, 0], [0, 1, 0], [0, 0, 1]], [[1, 0], [20, 5], [8, 6]])
+    #    result = reg.predict([[1,2], [8,9], [6,7]])
+    #    assert (result[0] == [1,0]).all()
+    #    assert (result[1] == [8,6]).all()
+    #    assert (result[2] == [20, 5]).all()
+
+    def test_predict1d(self):
+        reg = RegularGrid()
+        points = np.array([[1], [6], [8]])
+        V = np.array([[1, 0], [20, 5], [8, 6]])  # r, n = 2, 3
+        reg.fit(points, V)
+        result = reg.predict([[1], [8], [6]])
+        assert (result[0] == [1, 0]).all()
+        assert (result[1] == [8, 6]).all()
+        assert (result[2] == [20, 5]).all()
+
+    def test_predict1d_2(self):
+        reg = RegularGrid()
+        reg.fit([[1], [2]], [[1, 1], [2, 2]])
+        result = reg.predict([[1.5]])
+        assert (result[0] == [[1.5, 1.5]]).all()
+
+    def test_predict1d_3(self):
+        reg = RegularGrid()
+        reg.fit([1, 2], [[1, 1], [2, 2]])
+        result = reg.predict([[1.5]])
+        assert (result[0] == [[1.5, 1.5]]).all()
+
+    def test_with_db_predict(self):
+        reg = RegularGrid()
+        pod = POD()
+        db = Database(np.array([1, 2, 3])[:, None],
+                      np.array([1, 5, 3])[:, None])
+        rom = ReducedOrderModel(db, pod, reg)
+
+        rom.fit()
+        assert rom.predict([1]) == 1
+        assert rom.predict([2]) == 5
+        assert rom.predict([3]) == 3
+
+    def test_wrong1(self):
+        # wrong number of params
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", category=np.VisibleDeprecationWarning)
+            with self.assertRaises(Exception):
+                reg = Linear()
+                reg.fit([[1, 2], [6, ], [8, 9]], [[1, 0], [20, 5], [8, 6]])
+
+    def test_wrong2(self):
+        # wrong number of values
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", category=np.VisibleDeprecationWarning)
+            with self.assertRaises(Exception):
+                reg = Linear()
+                reg.fit([[1, 2], [6, ], [8, 9]], [[20, 5], [8, 6]])

--- a/tests/test_regular_grid.py
+++ b/tests/test_regular_grid.py
@@ -93,4 +93,3 @@ class TestRegularGrid(TestCase):
         assert rom.predict([1]) == 1
         assert rom.predict([2]) == 5
         assert rom.predict([3]) == 3
-    # TODO: test kvargs? depend on scipy version....

--- a/tests/test_regular_grid.py
+++ b/tests/test_regular_grid.py
@@ -1,5 +1,5 @@
 import numpy as np
-from unittest import TestCase
+from unittest import TestCase, main
 from ezyrb import RegularGrid, Database, POD, ReducedOrderModel
 
 
@@ -93,3 +93,15 @@ class TestRegularGrid(TestCase):
         assert rom.predict([1]) == 1
         assert rom.predict([2]) == 5
         assert rom.predict([3]) == 3
+
+    def test_fails(self):
+        reg = RegularGrid()
+        reg = RegularGrid()
+        p = [[1, 2]]
+        V = [[1, 1], [2, 2]]
+        with self.assertRaises(ValueError):
+            reg.fit(p, V)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_regular_grid.py
+++ b/tests/test_regular_grid.py
@@ -1,8 +1,6 @@
 import numpy as np
-import warnings
-
 from unittest import TestCase
-from ezyrb import Linear, Database, POD, ReducedOrderModel, RegularGrid
+from ezyrb import RegularGrid  # Database, POD, ReducedOrderModel
 
 
 class TestRegularGrid(TestCase):
@@ -13,14 +11,6 @@ class TestRegularGrid(TestCase):
     def test_default_params(self):
         reg = RegularGrid()
         assert np.isnan(reg.fill_value)
-
-    # def test_predict(self):
-    #    reg = Linear()
-    #    reg.fit([[1, 0, 0], [0, 1, 0], [0, 0, 1]], [[1, 0], [20, 5], [8, 6]])
-    #    result = reg.predict([[1,2], [8,9], [6,7]])
-    #    assert (result[0] == [1,0]).all()
-    #    assert (result[1] == [8,6]).all()
-    #    assert (result[2] == [20, 5]).all()
 
     def test_predict1d(self):
         reg = RegularGrid()
@@ -53,35 +43,3 @@ class TestRegularGrid(TestCase):
 
     # TODO: test kvargs? depend on scipy version....
     # TODO: rom.fit() does not work, use reduction.fit() and approximation.fit() instead.
-
-    # def test_with_db_predict(self):
-    #     reg = RegularGrid()
-    #     pod = POD()
-    #     x1 = np.array([1, 2, 3])
-    #     xx, _ = np.meshgrid(x1, 1, indexing="ij")
-    #     db = Database(xx,
-    #                   np.array([1, 5, 3])[:, None])
-    #     rom = ReducedOrderModel(db, pod, reg)
-
-    #     rom.fit()
-    #     assert rom.predict([1]) == 1
-    #     assert rom.predict([2]) == 5
-    #     assert rom.predict([3]) == 3
-
-    # def test_wrong1(self):
-    #     # wrong number of params
-    #     with warnings.catch_warnings():
-    #         warnings.filterwarnings(
-    #             "ignore", category=np.VisibleDeprecationWarning)
-    #         with self.assertRaises(Exception):
-    #             reg = Linear()
-    #             reg.fit([[1, 2], [6, ], [8, 9]], [[1, 0], [20, 5], [8, 6]])
-
-    # def test_wrong2(self):
-    #     # wrong number of values
-    #     with warnings.catch_warnings():
-    #         warnings.filterwarnings(
-    #             "ignore", category=np.VisibleDeprecationWarning)
-    #         with self.assertRaises(Exception):
-    #             reg = Linear()
-    #             reg.fit([[1, 2], [6, ], [8, 9]], [[20, 5], [8, 6]])

--- a/tests/test_regular_grid.py
+++ b/tests/test_regular_grid.py
@@ -4,13 +4,6 @@ from ezyrb import RegularGrid, Database, POD, ReducedOrderModel
 
 
 class TestRegularGrid(TestCase):
-    def test_params(self):
-        reg = RegularGrid(fill_value=0)
-        assert reg.fill_value == 0
-
-    def test_default_params(self):
-        reg = RegularGrid()
-        assert np.isnan(reg.fill_value)
 
     def test_1D_1mode(self):
         reg = RegularGrid()
@@ -101,4 +94,3 @@ class TestRegularGrid(TestCase):
         assert rom.predict([2]) == 5
         assert rom.predict([3]) == 3
     # TODO: test kvargs? depend on scipy version....
-    # TODO: rom.fit() does not work, use reduction.fit() and approximation.fit() instead.

--- a/tests/test_regular_grid.py
+++ b/tests/test_regular_grid.py
@@ -24,9 +24,10 @@ class TestRegularGrid(TestCase):
 
     def test_predict1d(self):
         reg = RegularGrid()
-        points = np.array([[1], [6], [8]])
-        V = np.array([[1, 0], [20, 5], [8, 6]])  # r, n = 2, 3
-        reg.fit(points, V)
+        x1 = np.array([1, 6, 8])
+        V = np.array([[1, 0], [20, 5], [8, 6]])  # n, r = 3, 2
+        grid = [x1, ]
+        reg.fit(grid, V)
         result = reg.predict([[1], [8], [6]])
         assert (result[0] == [1, 0]).all()
         assert (result[1] == [8, 6]).all()
@@ -34,42 +35,53 @@ class TestRegularGrid(TestCase):
 
     def test_predict1d_2(self):
         reg = RegularGrid()
-        reg.fit([[1], [2]], [[1, 1], [2, 2]])
+        x1 = [1, 2]
+        reg.fit([x1, ], [[1, 1], [2, 2]])
         result = reg.predict([[1.5]])
         assert (result[0] == [[1.5, 1.5]]).all()
 
-    def test_predict1d_3(self):
+    def test_predict2d(self):
         reg = RegularGrid()
-        reg.fit([1, 2], [[1, 1], [2, 2]])
-        result = reg.predict([[1.5]])
-        assert (result[0] == [[1.5, 1.5]]).all()
+        x1 = [1, 2, 3]
+        x2 = [4, 5, 6, 7]
+        V = [[1, 21], [2, 22], [3, 23], [4, 24], [5, 25], [6, 26],
+             [7, 27], [8, 28], [9, 29], [10, 30], [11, 31], [12, 32]]
+        reg.fit([x1, x2], V, method="linear")
+        result = reg.predict([[1, 4], [1, 5]])
+        assert (result[0] == [1, 21]).all()
+        assert (result[1] == [2, 22]).all()
 
-    def test_with_db_predict(self):
-        reg = RegularGrid()
-        pod = POD()
-        db = Database(np.array([1, 2, 3])[:, None],
-                      np.array([1, 5, 3])[:, None])
-        rom = ReducedOrderModel(db, pod, reg)
+    # TODO: test kvargs? depend on scipy version....
+    # TODO: rom.fit() does not work, use reduction.fit() and approximation.fit() instead.
 
-        rom.fit()
-        assert rom.predict([1]) == 1
-        assert rom.predict([2]) == 5
-        assert rom.predict([3]) == 3
+    # def test_with_db_predict(self):
+    #     reg = RegularGrid()
+    #     pod = POD()
+    #     x1 = np.array([1, 2, 3])
+    #     xx, _ = np.meshgrid(x1, 1, indexing="ij")
+    #     db = Database(xx,
+    #                   np.array([1, 5, 3])[:, None])
+    #     rom = ReducedOrderModel(db, pod, reg)
 
-    def test_wrong1(self):
-        # wrong number of params
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", category=np.VisibleDeprecationWarning)
-            with self.assertRaises(Exception):
-                reg = Linear()
-                reg.fit([[1, 2], [6, ], [8, 9]], [[1, 0], [20, 5], [8, 6]])
+    #     rom.fit()
+    #     assert rom.predict([1]) == 1
+    #     assert rom.predict([2]) == 5
+    #     assert rom.predict([3]) == 3
 
-    def test_wrong2(self):
-        # wrong number of values
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", category=np.VisibleDeprecationWarning)
-            with self.assertRaises(Exception):
-                reg = Linear()
-                reg.fit([[1, 2], [6, ], [8, 9]], [[20, 5], [8, 6]])
+    # def test_wrong1(self):
+    #     # wrong number of params
+    #     with warnings.catch_warnings():
+    #         warnings.filterwarnings(
+    #             "ignore", category=np.VisibleDeprecationWarning)
+    #         with self.assertRaises(Exception):
+    #             reg = Linear()
+    #             reg.fit([[1, 2], [6, ], [8, 9]], [[1, 0], [20, 5], [8, 6]])
+
+    # def test_wrong2(self):
+    #     # wrong number of values
+    #     with warnings.catch_warnings():
+    #         warnings.filterwarnings(
+    #             "ignore", category=np.VisibleDeprecationWarning)
+    #         with self.assertRaises(Exception):
+    #             reg = Linear()
+    #             reg.fit([[1, 2], [6, ], [8, 9]], [[20, 5], [8, 6]])

--- a/tests/test_regular_grid.py
+++ b/tests/test_regular_grid.py
@@ -41,5 +41,23 @@ class TestRegularGrid(TestCase):
         assert (result[0] == [1, 21]).all()
         assert (result[1] == [2, 22]).all()
 
+    def test_points2grid_2D():
+        x1 = [.1, .2, .3]
+        x2 = [4, 5, 6, 7]
+        xx1, xx2 = np.meshgrid(x1, x2, indexing="ij")
+        V = np.arange(len(x1)*len(x2)*2).reshape(-1, 2)
+        pts = np.c_[xx1.ravel(), xx2.ravel()]
+
+        random_order = np.arange(len(pts))
+        np.random.shuffle(random_order)
+        pts_scrmbld = pts[random_order, :]
+        V_scrmbld = V[random_order, :]
+
+        reg = RegularGrid()
+
+        (x1, x2), V_unscrambled = reg.get_grid_axes(pts_scrmbld, V_scrmbld)
+
+        assert np.allclose(V_unscrambled, V)
+
     # TODO: test kvargs? depend on scipy version....
     # TODO: rom.fit() does not work, use reduction.fit() and approximation.fit() instead.


### PR DESCRIPTION
 see #243

The class needs a grid, i.e. something like `grid = ([0.1, 0.2, 0.3], [1, 2, 3, 4, 5])`, not a list of points such as `points = [[0.1, 1], [0.1, 2], [0.1, 3], ..., [0.3, 5]]`. That means [rom.fit()](https://github.com/mathLab/EZyRB/blob/8a51f55e08d520e2c661d57c67a99e03dc1253ee/ezyrb/reducedordermodel.py#L67) does not work, the method assumes we want to use the points from the database to construct the interpolator. Instead the user has to call `reduction.fit(...)` first and then `rg_approximation.fit(...)` with the proper grid.
Although the interpolation returns what we expect in the tests, I have not tested it in a full ROM yet.