### PR TITLE
Some refactoring of the POD class

### DIFF
--- a/ezyrb/parallel/pod.py
+++ b/ezyrb/parallel/pod.py
@@ -4,7 +4,6 @@ Three different methods can be employed: Truncated Singular Value
 Decomposition, Truncated Randomized Singular Value Decomposition, Truncated
 Singular Value Decomposition via correlation matrix.
 """
-
 try:
     from scipy.linalg import eigh
 except ImportError:
@@ -14,7 +13,6 @@ import numpy as np
 from pycompss.api.task import task
 from pycompss.api.parameter import INOUT, IN
 from .reduction import Reduction
-
 
 class POD(Reduction):
     """
@@ -55,13 +53,21 @@ class POD(Reduction):
                       omega_rank=10)
         >>> pod = POD('correlation_matrix', rank=10, save_memory=False)
     """
-
-    def __init__(self, method="svd", **kwargs):
+    def __init__(self, method='svd', **kwargs):
 
         available_methods = {
-            "svd": (self._svd, {"rank": -1}),
-            "randomized_svd": (self._rsvd, {"rank": -1, "subspace_iteration": 1, "omega_rank": 0}),
-            "correlation_matrix": (self._corrm, {"rank": -1, "save_memory": False}),
+            'svd': (self._svd, {
+                'rank': -1
+            }),
+            'randomized_svd': (self._rsvd, {
+                'rank': -1,
+                'subspace_iteration': 1,
+                'omega_rank': 0
+            }),
+            'correlation_matrix': (self._corrm, {
+                'rank': -1,
+                'save_memory': False
+            }),
         }
 
         self._modes = None
@@ -71,11 +77,9 @@ class POD(Reduction):
         if method is None:
             raise RuntimeError(
                 "Invalid method for POD. Please chose one among {}".format(
-                    ", ".join(available_methods)
-                )
-            )
+                    ', '.join(available_methods)))
 
-        self._method, args = method
+        self.__method, args = method
         args.update(kwargs)
 
         for hyperparam, value in args.items():
@@ -107,7 +111,7 @@ class POD(Reduction):
 
         :param numpy.ndarray X: the input snapshots matrix (stored by column)
         """
-        self._modes, self._singular_values = self._method(X)
+        self._modes, self._singular_values = self.__method(X)
         return self
 
     @task(returns=np.ndarray, target_direction=IN)
@@ -132,7 +136,8 @@ class POD(Reduction):
         predicted_sol = self.modes.dot(X)
 
         if database and database.scaler_snapshots:
-            predicted_sol = database.scaler_snapshots.inverse_transform(predicted_sol.T).T
+            predicted_sol = database.scaler_snapshots.inverse_transform(
+                    predicted_sol.T).T
 
         if 1 in predicted_sol.shape:
             predicted_sol = predicted_sol.ravel()
@@ -176,7 +181,6 @@ class POD(Reduction):
         :return: the number of modes
         :rtype: int
         """
-
         def omega(x):
             return 0.56 * x**3 - 0.95 * x**2 + 1.82 * x + 1.43
 
@@ -227,7 +231,8 @@ class POD(Reduction):
         constructing approximate matrix decompositions. N. Halko, P. G.
         Martinsson, J. A. Tropp.
         """
-        if self.omega_rank == 0 and isinstance(self.rank, int) and self.rank not in [0, -1]:
+        if (self.omega_rank == 0 and isinstance(self.rank, int)
+                and self.rank not in [0, -1]):
             omega_rank = self.rank * 2
         elif self.omega_rank == 0:
             omega_rank = X.shape[1] * 2

--- a/ezyrb/parallel/pod.py
+++ b/ezyrb/parallel/pod.py
@@ -4,6 +4,7 @@ Three different methods can be employed: Truncated Singular Value
 Decomposition, Truncated Randomized Singular Value Decomposition, Truncated
 Singular Value Decomposition via correlation matrix.
 """
+
 try:
     from scipy.linalg import eigh
 except ImportError:
@@ -13,6 +14,7 @@ import numpy as np
 from pycompss.api.task import task
 from pycompss.api.parameter import INOUT, IN
 from .reduction import Reduction
+
 
 class POD(Reduction):
     """
@@ -53,21 +55,13 @@ class POD(Reduction):
                       omega_rank=10)
         >>> pod = POD('correlation_matrix', rank=10, save_memory=False)
     """
-    def __init__(self, method='svd', **kwargs):
+
+    def __init__(self, method="svd", **kwargs):
 
         available_methods = {
-            'svd': (self._svd, {
-                'rank': -1
-            }),
-            'randomized_svd': (self._rsvd, {
-                'rank': -1,
-                'subspace_iteration': 1,
-                'omega_rank': 0
-            }),
-            'correlation_matrix': (self._corrm, {
-                'rank': -1,
-                'save_memory': False
-            }),
+            "svd": (self._svd, {"rank": -1}),
+            "randomized_svd": (self._rsvd, {"rank": -1, "subspace_iteration": 1, "omega_rank": 0}),
+            "correlation_matrix": (self._corrm, {"rank": -1, "save_memory": False}),
         }
 
         self._modes = None
@@ -77,9 +71,11 @@ class POD(Reduction):
         if method is None:
             raise RuntimeError(
                 "Invalid method for POD. Please chose one among {}".format(
-                    ', '.join(available_methods)))
+                    ", ".join(available_methods)
+                )
+            )
 
-        self.__method, args = method
+        self._method, args = method
         args.update(kwargs)
 
         for hyperparam, value in args.items():
@@ -111,7 +107,7 @@ class POD(Reduction):
 
         :param numpy.ndarray X: the input snapshots matrix (stored by column)
         """
-        self._modes, self._singular_values = self.__method(X)
+        self._modes, self._singular_values = self._method(X)
         return self
 
     @task(returns=np.ndarray, target_direction=IN)
@@ -136,8 +132,7 @@ class POD(Reduction):
         predicted_sol = self.modes.dot(X)
 
         if database and database.scaler_snapshots:
-            predicted_sol = database.scaler_snapshots.inverse_transform(
-                    predicted_sol.T).T
+            predicted_sol = database.scaler_snapshots.inverse_transform(predicted_sol.T).T
 
         if 1 in predicted_sol.shape:
             predicted_sol = predicted_sol.ravel()
@@ -181,6 +176,7 @@ class POD(Reduction):
         :return: the number of modes
         :rtype: int
         """
+
         def omega(x):
             return 0.56 * x**3 - 0.95 * x**2 + 1.82 * x + 1.43
 
@@ -231,8 +227,7 @@ class POD(Reduction):
         constructing approximate matrix decompositions. N. Halko, P. G.
         Martinsson, J. A. Tropp.
         """
-        if (self.omega_rank == 0 and isinstance(self.rank, int)
-                and self.rank not in [0, -1]):
+        if self.omega_rank == 0 and isinstance(self.rank, int) and self.rank not in [0, -1]:
             omega_rank = self.rank * 2
         elif self.omega_rank == 0:
             omega_rank = X.shape[1] * 2

--- a/ezyrb/reduction/pod.py
+++ b/ezyrb/reduction/pod.py
@@ -4,13 +4,14 @@ Three different methods can be employed: Truncated Singular Value
 Decomposition, Truncated Randomized Singular Value Decomposition, Truncated
 Singular Value Decomposition via correlation matrix.
 """
+
 import numpy as np
 
 from .reduction import Reduction
 
 
 class POD(Reduction):
-    def __init__(self, method='svd', **kwargs):
+    def __init__(self, method="svd", **kwargs):
         """
         Perform the Proper Orthogonal Decomposition.
 
@@ -50,18 +51,9 @@ class POD(Reduction):
             >>> pod = POD('correlation_matrix', rank=10, save_memory=False)
         """
         available_methods = {
-            'svd': (self._svd, {
-                'rank': -1
-            }),
-            'randomized_svd': (self._rsvd, {
-                'rank': -1,
-                'subspace_iteration': 1,
-                'omega_rank': 0
-            }),
-            'correlation_matrix': (self._corrm, {
-                'rank': -1,
-                'save_memory': False
-            }),
+            "svd": (self._svd, {"rank": -1}),
+            "randomized_svd": (self._rsvd, {"rank": -1, "subspace_iteration": 1, "omega_rank": 0}),
+            "correlation_matrix": (self._corrm, {"rank": -1, "save_memory": False}),
         }
 
         self._modes = None
@@ -73,7 +65,7 @@ class POD(Reduction):
                 f"Invalid method for POD. Please chose one among {', '.join(available_methods)}"
             )
 
-        self.__method, args = method
+        self._method, args = method
         args.update(kwargs)
 
         for hyperparam, value in args.items():
@@ -104,7 +96,7 @@ class POD(Reduction):
 
         :param numpy.ndarray X: the input snapshots matrix (stored by column)
         """
-        self._modes, self._singular_values = self.__method(X)
+        self._modes, self._singular_values = self._method(X)
         return self
 
     def transform(self, X):
@@ -158,6 +150,7 @@ class POD(Reduction):
         :return: the number of modes
         :rtype: int
         """
+
         def omega(x):
             return 0.56 * x**3 - 0.95 * x**2 + 1.82 * x + 1.43
 
@@ -208,8 +201,7 @@ class POD(Reduction):
         constructing approximate matrix decompositions. N. Halko, P. G.
         Martinsson, J. A. Tropp.
         """
-        if (self.omega_rank == 0 and isinstance(self.rank, int)
-                and self.rank not in [0, -1]):
+        if self.omega_rank == 0 and isinstance(self.rank, int) and self.rank not in [0, -1]:
             omega_rank = self.rank * 2
         elif self.omega_rank == 0:
             omega_rank = X.shape[1] * 2


### PR DESCRIPTION
see #256 
changes:
- removed dunder to avoid name mangling. This makes it easier to trace back and debug.
- arguments are no longer set dynamically using `**kwargs`.  Since arguments are explicit, debugging is easier, spelling errors can't pass unnoticed and IDE's can give hints.